### PR TITLE
Disconnect from soterd peers with different MAJOR versions from us

### DIFF
--- a/cmd/soterctl/config.go
+++ b/cmd/soterctl/config.go
@@ -200,7 +200,7 @@ func loadConfig() (*config, []string, error) {
 	appName = strings.TrimSuffix(appName, filepath.Ext(appName))
 	usageMessage := fmt.Sprintf("Use %s -h to show options", appName)
 	if preCfg.ShowVersion {
-		fmt.Println(appName, "version", version())
+		fmt.Println(appName, "version", version)
 		os.Exit(0)
 	}
 

--- a/cmd/soterctl/version.go
+++ b/cmd/soterctl/version.go
@@ -6,71 +6,11 @@
 package main
 
 import (
-	"bytes"
-	"fmt"
-	"strings"
+	"github.com/blang/semver"
 )
 
-// semanticAlphabet
-const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-"
-
-// These constants define the application version and follow the semantic
-// versioning 2.0.0 spec (http://semver.org/).
-const (
-	appMajor uint = 0
-	appMinor uint = 12
-	appPatch uint = 0
-
-	// appPreRelease MUST only contain characters from semanticAlphabet
-	// per the semantic versioning spec.
-	appPreRelease = "beta"
-)
-
-// appBuild is defined as a variable so it can be overridden during the build
-// process with '-ldflags "-X main.appBuild foo' if needed.  It MUST only
-// contain characters from semanticAlphabet per the semantic versioning spec.
-var appBuild string
-
-// version returns the application version as a properly formed string per the
-// semantic versioning 2.0.0 spec (http://semver.org/).
-func version() string {
-	// Start with the major, minor, and patch versions.
-	version := fmt.Sprintf("%d.%d.%d", appMajor, appMinor, appPatch)
-
-	// Append pre-release version if there is one.  The hyphen called for
-	// by the semantic versioning spec is automatically appended and should
-	// not be contained in the pre-release string.  The pre-release version
-	// is not appended if it contains invalid characters.
-	preRelease := normalizeVerString(appPreRelease)
-	if preRelease != "" {
-		version = fmt.Sprintf("%s-%s", version, preRelease)
-	}
-
-	// Append build metadata if there is any.  The plus called for
-	// by the semantic versioning spec is automatically appended and should
-	// not be contained in the build metadata string.  The build metadata
-	// string is not appended if it contains invalid characters.
-	build := normalizeVerString(appBuild)
-	if build != "" {
-		version = fmt.Sprintf("%s+%s", version, build)
-	}
-
-	return version
-}
-
-// normalizeVerString returns the passed string stripped of all characters which
-// are not valid according to the semantic versioning guidelines for pre-release
-// version and build metadata strings.  In particular they MUST only contain
-// characters in semanticAlphabet.
-func normalizeVerString(str string) string {
-	var result bytes.Buffer
-	for _, r := range str {
-		if strings.ContainsRune(semanticAlphabet, r) {
-			// Ignoring the error here since it can only fail if
-			// the the system is out of memory and there are much
-			// bigger issues at that point.
-			_, _ = result.WriteRune(r)
-		}
-	}
-	return result.String()
+var version = semver.Version{
+	Major: 0,
+	Minor: 13,
+	Patch: 0,
 }

--- a/config.go
+++ b/config.go
@@ -471,7 +471,7 @@ func loadConfig() (*config, []string, error) {
 	appName = strings.TrimSuffix(appName, filepath.Ext(appName))
 	usageMessage := fmt.Sprintf("Use %s -h to show usage", appName)
 	if preCfg.ShowVersion {
-		fmt.Println(appName, "version", version())
+		fmt.Println(appName, "version", version)
 		os.Exit(0)
 	}
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,10 @@
-hash: 60836bf42cdada7754bda4d00c65f885ba3e83ad759abca9c1d27fbd57344977
-updated: 2019-04-22T12:59:56.196483287-06:00
+hash: 27f5557ed3d8d5613926f8224229785d6b0d1accc3516eebdcd4780d45c7ea45
+updated: 2019-05-02T23:33:24.470145569-06:00
 imports:
 - name: github.com/aead/siphash
   version: 83563a290f60225eb120d724600b9690c3fb536f
+- name: github.com/blang/semver
+  version: ba2c2ddd89069b46a7011d4106f6868f17ee1705
 - name: github.com/btcsuite/go-socks
   version: 4720035b7bfd2a9bb130b1c184f8bbe41b6f0d0f
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -31,3 +31,5 @@ import:
   version: 83563a290f60225eb120d724600b9690c3fb536f
 - package: github.com/wcharczuk/go-chart
   version: 9852fce5a172598e72d16f4306f0f17a53d94eb4
+- package: github.com/blang/semver
+  version: ^3.6.1

--- a/peer/example_test.go
+++ b/peer/example_test.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"time"
 
+	"github.com/blang/semver"
 	"github.com/soteria-dag/soterd/chaincfg"
 	"github.com/soteria-dag/soterd/peer"
 	"github.com/soteria-dag/soterd/wire"
@@ -22,7 +23,7 @@ func mockRemotePeer() error {
 	// Configure peer to act as a simnet node that offers no services.
 	peerCfg := &peer.Config{
 		UserAgentName:    "peer",  // User agent name to advertise.
-		UserAgentVersion: "1.0.0", // User agent version to advertise.
+		UserAgentVersion: semver.Version{Major:1, Minor: 0, Patch: 0}, // User agent version to advertise.
 		ChainParams:      &chaincfg.SimNetParams,
 		TrickleInterval:  time.Second * 10,
 	}
@@ -68,7 +69,7 @@ func Example_newOutboundPeer() {
 	verack := make(chan struct{})
 	peerCfg := &peer.Config{
 		UserAgentName:    "peer",  // User agent name to advertise.
-		UserAgentVersion: "1.0.0", // User agent version to advertise.
+		UserAgentVersion: semver.Version{Major:1, Minor: 0, Patch: 0}, // User agent version to advertise.
 		ChainParams:      &chaincfg.SimNetParams,
 		Services:         0,
 		TrickleInterval:  time.Second * 10,

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2408,7 +2408,7 @@ func handleGetInfo(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (in
 	best := s.cfg.Chain.BestSnapshot()
 	dagState := s.cfg.Chain.DAGSnapshot()
 	ret := &soterjson.InfoChainResult{
-		Version:         int32(1000000*appMajor + 10000*appMinor + 100*appPatch),
+		Version:         int32(1000000*version.Major + 10000*version.Minor + 100*version.Patch),
 		ProtocolVersion: int32(maxProtocolVersion),
 		Blocks:          int32(dagState.BlkCount),
 		TimeOffset:      int64(s.cfg.TimeSource.Offset().Seconds()),

--- a/server.go
+++ b/server.go
@@ -68,7 +68,7 @@ var (
 
 	// userAgentVersion is the user agent version and is used to help
 	// identify ourselves to other soter peers.
-	userAgentVersion = fmt.Sprintf("%d.%d.%d", appMajor, appMinor, appPatch)
+	userAgentVersion = version
 )
 
 // zeroHash is the zero value hash (all zeros).  It is defined as a convenience.

--- a/soterd.go
+++ b/soterd.go
@@ -62,7 +62,7 @@ func soterdMain(serverChan chan<- *server) error {
 	defer soterdLog.Info("Shutdown complete")
 
 	// Show version at startup.
-	soterdLog.Infof("Version %s", version())
+	soterdLog.Infof("Version %s", version)
 
 	// Enable http profiling server if requested.
 	if cfg.Profile != "" {

--- a/version.go
+++ b/version.go
@@ -6,68 +6,11 @@
 package main
 
 import (
-	"bytes"
-	"fmt"
-	"strings"
+	"github.com/blang/semver"
 )
 
-// semanticAlphabet
-const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-"
-
-// These constants define the application version and follow the semantic
-// versioning 2.0.0 spec (http://semver.org/).
-const (
-	appMajor uint = 0
-	appMinor uint = 12
-	appPatch uint = 0
-
-	// appPreRelease MUST only contain characters from semanticAlphabet
-	// per the semantic versioning spec.
-	appPreRelease = "beta"
-)
-
-// appBuild is defined as a variable so it can be overridden during the build
-// process with '-ldflags "-X main.appBuild foo' if needed.  It MUST only
-// contain characters from semanticAlphabet per the semantic versioning spec.
-var appBuild string
-
-// version returns the application version as a properly formed string per the
-// semantic versioning 2.0.0 spec (http://semver.org/).
-func version() string {
-	// Start with the major, minor, and patch versions.
-	version := fmt.Sprintf("%d.%d.%d", appMajor, appMinor, appPatch)
-
-	// Append pre-release version if there is one.  The hyphen called for
-	// by the semantic versioning spec is automatically appended and should
-	// not be contained in the pre-release string.  The pre-release version
-	// is not appended if it contains invalid characters.
-	preRelease := normalizeVerString(appPreRelease)
-	if preRelease != "" {
-		version = fmt.Sprintf("%s-%s", version, preRelease)
-	}
-
-	// Append build metadata if there is any.  The plus called for
-	// by the semantic versioning spec is automatically appended and should
-	// not be contained in the build metadata string.  The build metadata
-	// string is not appended if it contains invalid characters.
-	build := normalizeVerString(appBuild)
-	if build != "" {
-		version = fmt.Sprintf("%s+%s", version, build)
-	}
-
-	return version
-}
-
-// normalizeVerString returns the passed string stripped of all characters which
-// are not valid according to the semantic versioning guidelines for pre-release
-// version and build metadata strings.  In particular they MUST only contain
-// characters in semanticAlphabet.
-func normalizeVerString(str string) string {
-	var result bytes.Buffer
-	for _, r := range str {
-		if strings.ContainsRune(semanticAlphabet, r) {
-			result.WriteRune(r)
-		}
-	}
-	return result.String()
+var version = semver.Version{
+	Major: 1,
+	Minor: 0,
+	Patch: 0,
 }


### PR DESCRIPTION
* Resolves issue #3
* Switched from custom semver code to github.com/blang/semver package
* Updated peer handshake behaviour, so that we will disconnect from peers not on the same MAJOR version as us. Peers without a matching User Agent string are not affected by this. (won't disconnect from 3rd-party soter clients)
* Bumped soterd version to 1.0.0, which will make soterd clients using this build or later disconnect from soterd peers running previous builds (0.12.0).